### PR TITLE
feat: отображение подсказок по истории просмотров

### DIFF
--- a/packages/renderer/src/utils/history-views/index.ts
+++ b/packages/renderer/src/utils/history-views/index.ts
@@ -6,7 +6,7 @@ import {getUserRate, isLoggedIn, saveUserRate} from '/@/utils/shikimori-api';
 // type HistoryViewsItemStates = 'planned' | 'watching' | 'rewatching' | 'completed' | 'on_hold' | 'dropped'
 
 
-interface HistoryViewsItem {
+export interface HistoryViewsItem {
   seriesId: number,
   episode: {
     number: number,
@@ -32,9 +32,10 @@ interface HistoryViews extends DBSchema {
   history: {
     value: HistoryViewsItem;
     key: HistoryViewsItem['seriesId'];
-    // indexes: {
-    //   'by-state': HistoryViewsItem['state']
-    // }
+    indexes: {
+      'by-updated-at': number
+      //   'by-state': HistoryViewsItem['state']
+    }
   };
   meta: Meta
 }
@@ -52,15 +53,18 @@ function getDB() {
     return dbPromise;
   }
 
-  dbPromise = openDB<HistoryViews>('history-views', 1, {
-    upgrade(db, oldVersion: number) {
+  dbPromise = openDB<HistoryViews>('history-views', 2, {
+    upgrade(db, oldVersion, _newVersion, transaction) {
       if (oldVersion < 1) {
-        db
-          .createObjectStore('history', {keyPath: 'seriesId'});
-        // .createIndex('by-state', 'state');
-
-
+        db.createObjectStore('history', {keyPath: 'seriesId'});
         db.createObjectStore('meta');
+      }
+
+      console.log({oldVersion});
+
+      if (oldVersion < 2) {
+        transaction.objectStore('history')
+          .createIndex('by-updated-at', 'updated_at');
       }
     },
   });
@@ -136,4 +140,11 @@ export async function getViewHistoryItem(seriesId: number): Promise<HistoryViews
   }
 
   return savedItem;
+}
+
+
+export function getHistoryItems(limit = 5): Promise<HistoryViewsItem[]> {
+  return getDB()
+    .then(db => db.getAllFromIndex('history', 'by-updated-at'))
+    .then(items => items.splice(-limit).reverse());
 }

--- a/packages/renderer/src/utils/history-views/index.ts
+++ b/packages/renderer/src/utils/history-views/index.ts
@@ -60,11 +60,8 @@ function getDB() {
         db.createObjectStore('meta');
       }
 
-      console.log({oldVersion});
-
       if (oldVersion < 2) {
-        transaction.objectStore('history')
-          .createIndex('by-updated-at', 'updated_at');
+        transaction.objectStore('history').createIndex('by-updated-at', 'updated_at');
       }
     },
   });

--- a/packages/renderer/src/utils/videoProvider/index.ts
+++ b/packages/renderer/src/utils/videoProvider/index.ts
@@ -70,7 +70,7 @@ export interface TranslationAuthor {
 /**
  * Возвращает {@link Series} по его MyAnimeListID
  */
-export function getSeries(malId: number): Promise<DeepReadonly<Series> | undefined> {
+export function getSeries(malId: number): Promise<Series | undefined> {
   return deDuplicatedRequest(
     `series-${malId}`,
     () => provider.getSeries(malId).then(s => s === undefined ? s : readonly(s)),


### PR DESCRIPTION
Работает плохо. Вынужденно загружает вообще всю историю просмотров, чтобы получить несколько последних элементов, как как нативные возможности idb не позволяют получить N записей по индексу с конца.

Смотри:
https://github.com/jakearchibald/idb/issues/176
https://github.com/w3c/IndexedDB/issues/130